### PR TITLE
[FE] 이슈 상세 페이지 0번째 comment margin값 수정, 새 코멘트 ui 추가

### DIFF
--- a/fe/src/components/common/CommentTextarea.tsx
+++ b/fe/src/components/common/CommentTextarea.tsx
@@ -16,6 +16,7 @@ const CommentTextarea = () => {
 
 export default CommentTextarea;
 const StyledCommentTextarea = styled.div`
+  width: 100%;
   position: relative;
   &:focus {
     label {

--- a/fe/src/components/issue-detail/IssueDetailBody.tsx
+++ b/fe/src/components/issue-detail/IssueDetailBody.tsx
@@ -2,6 +2,7 @@ import { Box } from '@material-ui/core';
 import AuthorAvatar from 'components/common/AuthorAvatar';
 import Comment from 'components/issue-detail/Comment';
 import styled from 'styled-components';
+import CommentTextarea from 'components/common/CommentTextarea';
 
 const IssueDetailBody = () => (
   <Box display="flex">
@@ -19,7 +20,7 @@ const IssueDetailBody = () => (
       <NewCommentWrapper display="flex">
         <AuthorAvatar size="L" name="eamon" />
         <Spacer />
-        {/* comment input ui */}
+        <CommentTextarea />
       </NewCommentWrapper>
     </CommentArea>
     <AssignArea></AssignArea>
@@ -30,11 +31,14 @@ const CommentArea = styled.section`
   width: 70%;
 `;
 
-const IssueDescription = styled.div``;
+const IssueDescription = styled.div`
+  margin-bottom: 1.5rem;
+`;
 
 const Comments = styled.ul`
+  all: unset;
   ${({ theme }) => theme.style.flexColum}
-  gap: 24px;
+  gap: 1.5rem;
 `;
 
 const NewCommentWrapper = styled(Box)`

--- a/fe/src/components/new-issue/NewIssueRight.tsx
+++ b/fe/src/components/new-issue/NewIssueRight.tsx
@@ -24,4 +24,3 @@ const StyledNewIssueRight = styled.div`
   height: fit-content;
   margin-left: 2rem;
 `;
- 


### PR DESCRIPTION
- 사이드바 컴포넌트(현재 이름 NewIssueRight)는 재사용을 위해 수정이 필요해서 일단 비워놨음